### PR TITLE
Removed lineHeight from the lable style so text renders completely.

### DIFF
--- a/checkbox.js
+++ b/checkbox.js
@@ -88,8 +88,7 @@ var styles = StyleSheet.create({
   },
   label: {
     fontSize: 15,
-    lineHeight: 15,
-    color: 'grey',
+    color: 'grey'
   }
 });
 


### PR DESCRIPTION
Just removed the line and now all text is visible, including descenders like g and y
